### PR TITLE
fix: ints can be both int and float

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Currently **ipld-schema-validator** supports the full IPLD Schema specification 
 * Struct with `stringpairs` representation
 * Struct with `stringjoin` representation
 
+### Floats & Ints
+
+Unfortunately, in JavaScript, an "integer" is really just a floating point number with a `0` after the decimal point (all numbers in JavaScript are IEEE754 double-precision floats). So we have no clean way to say whether a number is strictly an integer and _not_ a "float" in terms of the IPLD Data Model.
+
+This library takes the following approach:
+
+* An "int" is a number that passes the [`Number.isInteger()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger) test.
+* A "float" is a number that is not `Infinity` or `-Infinity`.
+
+Therefore, it is possible for the same number to pass as _both_ an int and a float IPLD kind.
+
 ## License & Copyright
 
 Copyright 2020 Rod Vagg

--- a/ipld-schema-validator.js
+++ b/ipld-schema-validator.js
@@ -4,7 +4,7 @@ const KindsDefn = `
 const Kinds = {
   Null: (obj) => obj === null,
   Int: (obj) => Number.isInteger(obj),
-  Float: (obj) => typeof obj === "number" && !Kinds.Int(obj),
+  Float: (obj) => typeof obj === "number" && Number.isFinite(obj),
   String: (obj) => typeof obj === "string",
   Bool: (obj) => typeof obj === "boolean",
   Bytes: (obj) => obj instanceof Uint8Array,

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -29,11 +29,15 @@ describe('Base kinds', () => {
 
   it('float', () => {
     const validator = SchemaValidator.create({ types: {} }, 'Float')
-    for (const obj of [null, 101, -101, 'a string', false, true, fauxCid, Uint8Array.from([1, 2, 3]), [1, 2, 3], { obj: 'nope' }, undefined]) {
+    for (const obj of [null, 'a string', false, true, fauxCid, Uint8Array.from([1, 2, 3]), [1, 2, 3], { obj: 'nope' }, undefined]) {
       assert.isFalse(validator(obj), `obj: ${obj} != 'float'`)
     }
     assert.isTrue(validator(1.01))
     assert.isTrue(validator(-1.01))
+    // sad, but unavoidable
+    assert.isTrue(validator(0))
+    assert.isTrue(validator(100))
+    assert.isTrue(validator(-100))
   })
 
   it('string', () => {


### PR DESCRIPTION
@vmx this should solve that problem you ran in to.

Better not tell @warpfork lest this further dents the high esteem in which he holds JavaScript.